### PR TITLE
Library additions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-12-13  Kirit Saelensminde  <kirit@felspar.com>
+ Fix the fg parser to allow whitspace and comments in more places.
+
 2017-10-08  Kirit Saelensminde  <kirit@felspar.com>
  * Add scripting call `setting` for manipulating settings.
  * Add parser support for all JSON atom values.

--- a/Cpp/fost-csj/parser.cpp
+++ b/Cpp/fost-csj/parser.cpp
@@ -34,7 +34,7 @@ namespace {
 */
 
 
-fostlib::csj::parser::parser(utf::u8_view str)
+fostlib::csj::parser::parser(f5::u8view str)
 : line_iter(splitter(str, '\n')),
     li_pos(line_iter.begin()),
     li_end(line_iter.end())

--- a/Cpp/fostgres-core/dbconnect.cpp
+++ b/Cpp/fostgres-core/dbconnect.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016, Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017, Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -7,6 +7,8 @@
 
 
 #include <fostgres/db.hpp>
+
+#include <mutex>
 
 
 fostlib::pg::connection fostgres::connection(
@@ -20,4 +22,3 @@ fostlib::pg::connection fostgres::connection(
     }
     return cnx;
 }
-

--- a/Cpp/fostgres-core/fostgres.cpp
+++ b/Cpp/fostgres-core/fostgres.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016, Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017, Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt

--- a/Cpp/fostgres-fg/contains.cpp
+++ b/Cpp/fostgres-fg/contains.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -7,6 +7,7 @@
 
 
 #include <fostgres/fg/contains.hpp>
+#include <fost/test>
 
 
 namespace {
@@ -24,7 +25,7 @@ namespace {
                 path /= p.key();
                 if ( super.has_key(path) ) {
                     auto part = walk(path, super, *p);
-                    if ( not part.isnull() ) return path;
+                    if ( part ) return path;
                 } else {
                     if ( *p != fostlib::json() ) {
                         return path;
@@ -41,8 +42,19 @@ namespace {
 }
 
 
-fostlib::nullable<fostlib::jcursor> fg::contains(const fostlib::json &super, const fostlib::json &sub) {
+fostlib::nullable<fostlib::jcursor> fg::contains(const fg::json &super, const fg::json &sub) {
     fostlib::jcursor path;
     return walk(path, super, sub);
+}
+
+
+void fg::throw_contains_error(fg::json actual, fg::json expected, fg::jcursor contains) {
+    fostlib::exceptions::test_failure error("Mismatched response body", __FILE__, __LINE__);
+    fostlib::insert(error.data(), "expected", expected);
+    fostlib::insert(error.data(), "actual", actual);
+    fostlib::insert(error.data(), "mismatch", "path", contains);
+    fostlib::insert(error.data(), "mismatch", "expected", expected[contains]);
+    fostlib::insert(error.data(), "mismatch", "actual", actual[contains]);
+    throw error;
 }
 

--- a/Cpp/fostgres-fg/fg.builtin.checks.cpp
+++ b/Cpp/fostgres-fg/fg.builtin.checks.cpp
@@ -1,0 +1,23 @@
+/*
+    Copyright 2017 Felspar Co Ltd. http://support.felspar.com/
+    Distributed under the Boost Software License, Version 1.0.
+    See accompanying file LICENSE_1_0.txt or copy at
+        http://www.boost.org/LICENSE_1_0.txt
+*/
+
+
+#include <fostgres/fg/contains.hpp>
+#include <fostgres/fg/fg.hpp>
+
+
+fg::frame::builtin fg::lib::contains =
+    [](fg::frame &stack, fg::json::const_iterator pos, fg::json::const_iterator end) {
+        auto data = stack.resolve(stack.argument("data", pos, end));
+        auto check = stack.resolve(stack.argument("check", pos, end));
+        auto result = fg::contains(data, check);
+        if ( result ) {
+            throw_contains_error(data, check, result.value());
+        }
+        return data;
+    };
+

--- a/Cpp/fostgres-fg/fg.builtin.cpp
+++ b/Cpp/fostgres-fg/fg.builtin.cpp
@@ -115,6 +115,7 @@ fg::frame fg::builtins() {
     funcs.symbols["testserver.headers"] = fg::json::object_t();
 
     funcs.native["cat"] = ::cat;
+    funcs.native["contains"] = lib::contains;
     funcs.native["DELETE"] = lib::del;
     funcs.native["GET"] = lib::get;
     funcs.native["lookup"] = ::lookup;

--- a/Cpp/fostgres-fg/fg.builtin.http.cpp
+++ b/Cpp/fostgres-fg/fg.builtin.http.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2016 Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt

--- a/Cpp/fostgres-fg/fg.builtin.http.cpp
+++ b/Cpp/fostgres-fg/fg.builtin.http.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2016 Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -10,8 +10,21 @@
 #include <fostgres/fg/fg.hpp>
 #include <fostgres/fg/fg.testserver.hpp>
 
+#include <fost/unicode>
+
 
 namespace {
+
+
+    auto body_data(const fostlib::mime &body) {
+        std::vector<unsigned char> data;
+        for ( const auto &part : body ) {
+            data.insert(data.end(),
+                reinterpret_cast<const char *>(part.first),
+                reinterpret_cast<const char *>(part.second));
+        }
+        return fostlib::json{f5::u8view(data)};
+    }
 
 
     template<typename O> inline
@@ -51,7 +64,7 @@ namespace {
             auto response = fg::mime_from_argument(stack, stack.argument("response", pos, end));
             fg::assert_comparable(*actual.first, *response);
         }
-        return fostlib::json();
+        return body_data(*actual.first);
     }
 
 

--- a/Cpp/fostgres-fg/fg.cpp
+++ b/Cpp/fostgres-fg/fg.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -7,6 +7,11 @@
 
 
 #include <fostgres/fg/fg.hpp>
+
+#include <fostgres/fostgres.hpp>
+
+
+const fostlib::module fg::c_fg(fostgres::c_fostgres, "fg");
 
 
 /*

--- a/Cpp/fostgres-fg/fg.frame.cpp
+++ b/Cpp/fostgres-fg/fg.frame.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -14,7 +14,7 @@
  */
 
 
-fg::frame::frame(const frame *f)
+fg::frame::frame(frame *f)
 : parent(f) {
 }
 
@@ -33,7 +33,7 @@ fg::json fg::frame::argument(
 }
 
 
-fostlib::string fg::frame::resolve_string(const json &code) const {
+fostlib::string fg::frame::resolve_string(const json &code) {
     if ( code.isatom() ) {
         return fostlib::coerce<fostlib::string>(code);
     } else if ( code.isarray() ) {
@@ -46,12 +46,24 @@ fostlib::string fg::frame::resolve_string(const json &code) const {
 }
 
 
-int64_t fg::frame::resolve_int(const json &code) const {
+int64_t fg::frame::resolve_int(const json &code) {
     if ( code.isatom() ) {
         return fostlib::coerce<int64_t>(code);
     } else {
         throw fostlib::exceptions::not_implemented(__func__,
             "Can't resolve to an int", code);
+    }
+}
+
+
+fg::json fg::frame::resolve(const json &code) {
+    /// S-expressions are always a JSON array. Everything else is a literal
+    /// and doesn't need to be resolved.
+    if ( code.isarray() ) {
+        frame stack(this);
+        return call(stack, code);
+    } else {
+        return code;
     }
 }
 

--- a/Cpp/fostgres-fg/mime.cpp
+++ b/Cpp/fostgres-fg/mime.cpp
@@ -75,7 +75,7 @@ void fg::assert_comparable(const fostlib::mime &actual, const fostlib::mime &exp
     } else if ( actual.headers()["Content-Type"].value() == "text/plain" ) {
         /// This should be CSJ
         auto actual_data = body_data(actual);
-        fostlib::csj::parser actual_body{fostlib::utf::u8_view(actual_data)};
+        fostlib::csj::parser actual_body{f5::u8view(actual_data)};
         auto actual_iter = actual_body.begin(), actual_end = actual_body.end();
         auto expected_body = mime_to_json(expected);
         for ( auto row : expected_body["rows"] ) {

--- a/Cpp/fostgres-fg/mime.cpp
+++ b/Cpp/fostgres-fg/mime.cpp
@@ -64,13 +64,7 @@ void fg::assert_comparable(const fostlib::mime &actual, const fostlib::mime &exp
         auto expected_body = mime_to_json(expected);
         auto contains = fg::contains(actual_body, expected_body);
         if ( contains ) {
-            fostlib::exceptions::test_failure error("Mismatched response body", __FILE__, __LINE__);
-            fostlib::insert(error.data(), "expected", expected_body);
-            fostlib::insert(error.data(), "actual", actual_body);
-            fostlib::insert(error.data(), "mismatch", "path", contains.value());
-            fostlib::insert(error.data(), "mismatch", "expected", expected_body[contains.value()]);
-            fostlib::insert(error.data(), "mismatch", "actual", actual_body[contains.value()]);
-            throw error;
+            throw_contains_error(expected_body, actual_body, contains.value());
         }
     } else if ( actual.headers()["Content-Type"].value() == "text/plain" ) {
         /// This should be CSJ

--- a/Cpp/fostgres/response.csj.cpp
+++ b/Cpp/fostgres/response.csj.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016, Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017, Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -188,7 +188,7 @@ namespace {
         fostgres::updater handler(m.configuration["PATCH"], cnx, m, req);
 
         // Interpret body as UTF8 and split into lines. Ensure it's not empty
-        fostlib::csj::parser data(fostlib::utf::u8_view(req.data()->data()));
+        fostlib::csj::parser data(f5::u8view(req.data()->data()));
         logger("header", data.header());
 
         // Parse each line and send it to the database
@@ -242,7 +242,7 @@ namespace {
         // record the keys seen
         {
             // Interpret body as UTF8 and split into lines. Ensure it's not empty
-            fostlib::csj::parser data(fostlib::utf::u8_view(req.data()->data()));
+            fostlib::csj::parser data(f5::u8view(req.data()->data()));
             logger("header", data.header());
             std::size_t records{0};
             std::vector<fostlib::json> key_match;

--- a/Cpp/fostgres/sql.cpp
+++ b/Cpp/fostgres/sql.cpp
@@ -7,6 +7,7 @@
 
 
 #include <fost/log>
+#include <fostgres/callback.hpp>
 #include <fostgres/db.hpp>
 #include <fostgres/fostgres.hpp>
 #include <fostgres/matcher.hpp>
@@ -20,7 +21,7 @@ namespace {
     std::vector<fostgres::cnx_callback_fn> g_callbacks;
 }
 
-void fostgres::register_cnx_callback(cnx_callback_fn cb) {
+fostgres::register_cnx_callback::register_cnx_callback(cnx_callback_fn cb) {
     std::unique_lock<std::mutex> lock{g_cb_mut};
     g_callbacks.push_back(std::move(cb));
 }
@@ -203,4 +204,3 @@ std::pair<std::vector<fostlib::string>, fostlib::pg::recordset> fostgres::select
             : fostgres::sql(cnx, fostlib::coerce<fostlib::string>(select));
     }
 }
-

--- a/Cpp/include/fost/csj.parser.hpp
+++ b/Cpp/include/fost/csj.parser.hpp
@@ -51,15 +51,15 @@ namespace fostlib {
 
         /// Iterate over a file of CSJ like data
         class parser {
-            using line_iter_t = splitter_result<utf::u8_view, utf::u8_view, 1u>;
+            using line_iter_t = splitter_result<f5::u8view, f5::u8view, 1u>;
             line_iter_t line_iter;
             line_iter_t::const_iterator li_pos, li_end;
             std::vector<fostlib::string> headers;
-            headers_parser<f5::const_u32u16_iterator<utf::u8_view::const_iterator>> headers_p;
-            line_parser<f5::const_u32u16_iterator<utf::u8_view::const_iterator>> line_p;
+            headers_parser<f5::const_u32u16_iterator<f5::u8view::const_iterator>> headers_p;
+            line_parser<f5::const_u32u16_iterator<f5::u8view::const_iterator>> line_p;
         public:
             /// Initialise from a string
-            parser(utf::u8_view);
+            parser(f5::u8view);
 
             /// Return the header column names
             const auto &header() const {

--- a/Cpp/include/fostgres/callback.hpp
+++ b/Cpp/include/fostgres/callback.hpp
@@ -1,0 +1,31 @@
+/*
+    Copyright 2016-2017, Felspar Co Ltd. http://support.felspar.com/
+    Distributed under the Boost Software License, Version 1.0.
+    See accompanying file LICENSE_1_0.txt or copy at
+        http://www.boost.org/LICENSE_1_0.txt
+*/
+
+
+#pragma once
+
+
+#include <fost/http>
+#include <fost/http.server.hpp>
+#include <fost/postgres>
+
+
+namespace fostgres {
+
+
+    /// Register a callback to be called when a database connection
+    /// is established.
+    using cnx_callback_fn = std::function<void(fostlib::pg::connection&, const fostlib::http::server::request&)>;
+    /// Create a const static instance of this class giving it the lambda
+    /// you want executed on each database connect.
+    class register_cnx_callback {
+    public:
+        register_cnx_callback(cnx_callback_fn);
+    };
+
+
+}

--- a/Cpp/include/fostgres/db.hpp
+++ b/Cpp/include/fostgres/db.hpp
@@ -26,4 +26,3 @@ namespace fostgres {
 
 
 }
-

--- a/Cpp/include/fostgres/fg/contains.hpp
+++ b/Cpp/include/fostgres/fg/contains.hpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -9,7 +9,7 @@
 #pragma once
 
 
-#include <fost/core>
+#include <fostgres/fg/fg.hpp>
 
 
 namespace fg {
@@ -23,6 +23,11 @@ namespace fg {
     /// although a null in sub means that the key doesn't have to
     /// exist in `super`.
     fostlib::nullable<fostlib::jcursor> contains(const fostlib::json &super, const fostlib::json &sub);
+
+    /// If data is returned by the contains then we can throw an error
+    /// in a standard format.
+    [[noreturn]]
+    void throw_contains_error(json expected, json actual, jcursor contains_error);
 
 
 }

--- a/Cpp/include/fostgres/fg/fg.hpp
+++ b/Cpp/include/fostgres/fg/fg.hpp
@@ -19,6 +19,7 @@ namespace fg {
 
 
     using json = fostlib::json;
+    using jcursor = fostlib::jcursor;
 
 
     /// Parse an fg script and return its JSON representation
@@ -98,7 +99,8 @@ namespace fg {
 
 
     namespace lib {
-        extern frame::builtin del, get, patch, post, put, sql_file, sql_insert;
+        extern frame::builtin contains, del, get, patch, post, put,
+            sql_file, sql_insert;
     }
 
 

--- a/Cpp/include/fostgres/fg/fg.hpp
+++ b/Cpp/include/fostgres/fg/fg.hpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://support.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://support.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -13,6 +13,9 @@
 
 
 namespace fg {
+
+
+    const extern fostlib::module c_fg;
 
 
     using json = fostlib::json;
@@ -30,9 +33,9 @@ namespace fg {
     public:
         using builtin = std::function<json(frame &, json::const_iterator, json::const_iterator)>;
 
-        frame(const frame *parent);
+        frame(frame *parent);
 
-        const frame *parent;
+        frame *parent;
         std::map<fostlib::string, builtin> native;
         std::map<fostlib::string, json> symbols;
 
@@ -40,9 +43,11 @@ namespace fg {
         json argument(const fostlib::string &name, json::const_iterator &pos, json::const_iterator end);
 
         /// Turn an expression into a string
-        fostlib::string resolve_string(const json &) const;
+        fostlib::string resolve_string(const json &);
         /// Turn an expression into an integer
-        int64_t resolve_int(const json &) const;
+        int64_t resolve_int(const json &);
+        /// Expect that the JSON represents executable code
+        json resolve(const json &);
 
         /// Lookup a symbol
         json lookup(const fostlib::string &name) const;

--- a/Cpp/include/fostgres/fg/parser.hpp
+++ b/Cpp/include/fostgres/fg/parser.hpp
@@ -33,9 +33,9 @@ namespace fg {
             comment_p = qi::lit('#') >> *(qi::standard_wide::char_ - newline);
             comment = qi::omit[comment_p];
 
-            linebreak = -comment >> newline;
+            linebreak = *space >> -comment >> newline;
 
-            identifier_seq= +(qi::standard_wide::char_ - (space | newline | qi::lit(')')));
+            identifier_seq= +(qi::standard_wide::char_ - (space | newline | qi::lit(')') | qi::lit('#')));
             identifier = identifier_seq[boost::phoenix::bind([](auto &v, auto &s) {
                     v = fostlib::json(s);
                 }, qi::_val, qi::_1)];
@@ -48,7 +48,7 @@ namespace fg {
                     }
                     v = arr;
                 }, qi::_val, qi::_1)];
-            full_sexpr = qi::lit('(') >> inner_sexpr_json >> qi::lit(')');
+            full_sexpr = qi::lit('(') >> *space >> inner_sexpr_json >> *space >> qi::lit(')');
 
             top = qi::omit[*linebreak] >> -(inner_sexpr_json % +linebreak) >> qi::omit[*linebreak];
         }

--- a/Cpp/include/fostgres/sql.hpp
+++ b/Cpp/include/fostgres/sql.hpp
@@ -19,11 +19,6 @@ namespace fostgres {
     struct match;
 
 
-    /// Register a callback to be called when a database connection
-    /// is established.
-    using cnx_callback_fn = std::function<void(fostlib::pg::connection&, const fostlib::http::server::request&)>;
-    void register_cnx_callback(cnx_callback_fn);
-
     /// Return a database connection
     fostlib::pg::connection connection(
         fostlib::json config, const fostlib::http::server::request &req);
@@ -54,4 +49,3 @@ namespace fostgres {
 
 
 }
-

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To look at something concrete let's think about a database that holds films and 
 
 This means:
 
-* We are going to return a JSON ojbect made up from the colums in the `SELECT`.
-* The path is going to have the word "film" followed by what is going to become the first parameter in the `SELECT` statement. It should look something like `/film/terminator`
+* We are going to return a JSON object made up from the columns in the `SELECT`.
+* The path is going to have the word "film" followed by what is going to become the first parameter in the `SELECT` statement. It should look something like `/film/t1`
 * The GET will issue the specified SELECT and then return the object (or a 404 if nothing is matched).
 
 The JSON object that is returned might look like this:


### PR DESCRIPTION
This isn't quite done yet, but going to start here. This adds a large number of features to the scripting language so that there is a bit more flexibility to do more sophisticated things. There are new library functions:

* `set` & `set-path` (allow bindings to be set and manipulated)
* `lookup` returns the value of a binding
* `cat` concatenates a number of strings
* Tests like `POST` now return the response body as a string (this will not work with binary data). Could probably try to do a JSON/CSJ parse as well, and if the data isn't textual maybe base64 encode it...

The introduction of `set` means that the stack is no longer immutable. I'm kind of OK with that here because it's just too useful.