### PR TITLE
fostgres.sql POST can support configuration array

### DIFF
--- a/Cpp/fostgres/response.object.cpp
+++ b/Cpp/fostgres/response.object.cpp
@@ -92,6 +92,49 @@ namespace {
             return get(cnx, config, m, req);
         }
     }
+
+    std::pair<boost::shared_ptr<fostlib::mime>, int> proc_post(
+            fostlib::pg::connection &cnx,
+            const fostlib::json &config,
+            const fostgres::match &m,
+            fostlib::http::server::request &req,
+            const fostlib::json &post_config,
+            const fostlib::json &body) {
+        if (post_config.has_key("columns")) {
+            return fostgres::updater{post_config, cnx, m, req}.upsert(body).first;
+        } else {
+            fostlib::string relation =
+                    fostlib::coerce<fostlib::string>(post_config["table"]);
+            fostlib::json keys(calc_keys(m, post_config["keys"]));
+            fostlib::json values(calc_values(body, post_config["attributes"]));
+            cnx.upsert(relation.c_str(), keys, values);
+        }
+
+        fostlib::string relation =
+                fostlib::coerce<fostlib::string>(post_config["table"]);
+        fostlib::json col_config = post_config["columns"];
+        fostlib::json values;
+        for (auto col_def = col_config.begin(); col_def != col_config.end();
+             ++col_def) {
+            const auto name = fostlib::coerce<fostlib::string>(col_def.key());
+            const auto data =
+                    fostgres::datum(name, *col_def, m.arguments, body, req);
+            if (data) { fostlib::insert(values, name, data.value()); }
+        }
+        const fostlib::json &ret_cols = post_config["returning"];
+        std::vector<fostlib::string> returning;
+        std::transform(
+                ret_cols.begin(), ret_cols.end(), std::back_inserter(returning),
+                [](const auto &s) {
+                    return fostlib::coerce<fostlib::string>(s);
+                });
+        if (not returning.size()) { returning.emplace_back("*"); }
+        auto result = fostgres::column_names(
+                cnx.insert(relation.c_str(), values, returning));
+        cnx.commit();
+        return fostgres::response_object(std::move(result), config);
+    }
+
     std::pair<boost::shared_ptr<fostlib::mime>, int>
             post(fostlib::pg::connection &cnx,
                  const fostlib::json &config,
@@ -99,40 +142,17 @@ namespace {
                  fostlib::http::server::request &req) {
         fostlib::json body{fostlib::json::parse(fostlib::coerce<fostlib::string>(
                 fostlib::coerce<fostlib::utf8_string>(req.data()->data())))};
-        if (m.configuration["POST"].has_key("table")) {
-            fostlib::string relation = fostlib::coerce<fostlib::string>(
-                    m.configuration["POST"]["table"]);
-            fostlib::json col_config = m.configuration["POST"]["columns"];
-            fostlib::json values;
-            for (auto col_def = col_config.begin(); col_def != col_config.end();
-                 ++col_def) {
-                const auto name =
-                        fostlib::coerce<fostlib::string>(col_def.key());
-                const auto data =
-                        fostgres::datum(name, *col_def, m.arguments, body, req);
-                if (data) { fostlib::insert(values, name, data.value()); }
-            }
-            const fostlib::json &ret_cols =
-                    m.configuration["POST"]["returning"];
-            std::vector<fostlib::string> returning;
-            std::transform(
-                    ret_cols.begin(), ret_cols.end(),
-                    std::back_inserter(returning), [](const auto &s) {
-                        return fostlib::coerce<fostlib::string>(s);
-                    });
-            if (not returning.size()) { returning.emplace_back("*"); }
-            auto result = fostgres::column_names(
-                    cnx.insert(relation.c_str(), values, returning));
-            cnx.commit();
-            return fostgres::response_object(std::move(result), config);
+        auto const post_config = m.configuration["POST"];
+        if (post_config.has_key("table")) {
+            return proc_post(cnx, config, m, req, post_config, body);
         }
-        auto const fn_name = fostlib::coerce<fostlib::utf8_string>(fostlib::coerce<fostlib::string>(
-                    m.configuration["POST"]["function"]));
-        fostlib::json args = m.configuration["POST"]["args"];
+        auto const fn_name = fostlib::coerce<fostlib::utf8_string>(
+                fostlib::coerce<fostlib::string>(post_config["function"]));
+        fostlib::json args = post_config["args"];
         std::vector<fostlib::json> arguments;
         std::transform(
-                args.begin(), args.end(),
-                std::back_inserter(arguments), [&](const auto &s) {
+                args.begin(), args.end(), std::back_inserter(arguments),
+                [&](const auto &s) {
                     return fostgres::datum(s, {}, body, req).value();
                 });
         auto procedure = cnx.procedure(fn_name);


### PR DESCRIPTION
**Example configuration**
```
{
  "view":"fostgres.sql",
  "configuration":{
    "sql":[
      {
        "path":[

        ],
        "return":"object",
        "POST":[
          {
            "table":"odin.identity",
            "columns":{
              "id":{
                "source":[
                  "request",
                  "headers",
                  "__odin_reference"
                ]
              }
            }
          },
          {
            "table":"odin.credentials_password_ledger",
            "columns":{
              "reference":{
                "source":[
                  "request",
                  "headers",
                  "__odin_reference"
                ]
              },
              "identity_id":{
                "source":[
                  "request",
                  "headers",
                  "__odin_reference"
                ]
              },
              "login":{
                "source":[
                  "body",
                  "username"
                ]
              },
              "password":{
                "source":[
                  "request",
                  "headers",
                  "__hash"
                ]
              },
              "process":{
                "source":[
                  "request",
                  "headers",
                  "__hash_process"
                ]
              }
            }
          },
          {
            "table":"odin.identity_full_name_ledger",
            "columns":{
              "reference":{
                "source":[
                  "request",
                  "headers",
                  "__odin_reference"
                ]
              },
              "identity_id":{
                "source":[
                  "request",
                  "headers",
                  "__odin_reference"
                ]
              },
              "full_name":{
                "source":[
                  "body",
                  "full-name"
                ]
              }
            }
          },
          {
            "table":"odin.identity_email_ledger",
            "columns":{
              "reference":{
                "source":[
                  "request",
                  "headers",
                  "__odin_reference"
                ]
              },
              "identity_id":{
                "source":[
                  "request",
                  "headers",
                  "__odin_reference"
                ]
              },
              "email":{
                "source":[
                  "body",
                  "email"
                ]
              }
            }
          }
        ]
      }
    ]
  }
}
```