### PR TITLE
Catch the serialisation error and map that to the error code as well.

### DIFF
--- a/Cpp/fostgres/fostgres-control-error.cpp
+++ b/Cpp/fostgres/fostgres-control-error.cpp
@@ -27,6 +27,12 @@ namespace {
                 const fostlib::host &host) const {
             try {
                 return execute(config["execute"], path, req, host);
+            } catch (pqxx::serialization_failure const &e) {
+                if (config.has_key("40001")) {
+                    return execute(config["40001"], path, req, host);
+                } else {
+                    return execute(config[""], path, req, host);
+                }
             } catch (pqxx::sql_error const &e) {
                 if (config.has_key(e.sqlstate().c_str())) {
                     return execute(


### PR DESCRIPTION
In case libpqxx uses the `serialization_failure` exception which doesn't also map to an `sql_error` with the `sqlstate` set to 40001, do this manually.