### PR TITLE
Add a view to automatically retry Postgres serialisation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
     - git clone https://github.com/KayEss/fost-crypto.git
     - git clone https://github.com/KayEss/fost-internet.git
     - git clone https://github.com/KayEss/fost-postgres.git
-    - git clone https://github.com/KayEss/fost-web.git
+    - git clone https://github.com/KayEss/fost-web.git -b feature/fix-throw-plugins
     - git clone https://github.com/KayEss/f5-cord.git
     - git clone https://github.com/KayEss/f5-threading.git
     - git clone https://github.com/KayEss/json-schema.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 script:
     - mkdir build.tmp && cd build.tmp
     - 'if [ "$CXX" = "g++" ]; then export CC=gcc-8; export CXX=g++-8; fi'
-    - git clone https://github.com/KayEss/fost-base.git
+    - git clone https://github.com/KayEss/fost-base.git -b feature/dynlib-fix
     - git clone https://github.com/KayEss/fost-beanbag.git
     - git clone https://github.com/KayEss/fost-boost.git
     - git clone https://github.com/KayEss/fost-crypto.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ install:
 script:
     - mkdir build.tmp && cd build.tmp
     - 'if [ "$CXX" = "g++" ]; then export CC=gcc-8; export CXX=g++-8; fi'
-    - git clone https://github.com/KayEss/fost-base.git -b feature/dynlib-fix
+    - git clone https://github.com/KayEss/fost-base.git
     - git clone https://github.com/KayEss/fost-beanbag.git
     - git clone https://github.com/KayEss/fost-boost.git
     - git clone https://github.com/KayEss/fost-crypto.git
     - git clone https://github.com/KayEss/fost-internet.git
     - git clone https://github.com/KayEss/fost-postgres.git
-    - git clone https://github.com/KayEss/fost-web.git -b feature/fix-throw-plugins
+    - git clone https://github.com/KayEss/fost-web.git
     - git clone https://github.com/KayEss/f5-cord.git
     - git clone https://github.com/KayEss/f5-threading.git
     - git clone https://github.com/KayEss/json-schema.git

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-03-07  Kirit Saelensminde  <kirit@felspar.com>
+ Add a new view to retry Postgres serialisation errors.
+
 2019-02-22  Kirit Saelensminde  <kirit@felspar.com>
  Add a request logging middleware that stores the per-request log to the database.
 

--- a/Cpp/fostgres-fg/CMakeLists.txt
+++ b/Cpp/fostgres-fg/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(fostgres-fg
         fg.testserver.cpp
         mime.cpp
     )
-target_link_libraries(fostgres-fg fost-test fostgres)
+target_link_libraries(fostgres-fg fost-csj fost-test fostgres-core)
 set_target_properties(fostgres-fg PROPERTIES DEBUG_POSTFIX "-d")
 install(TARGETS fostgres-fg LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 

--- a/Cpp/fostgres-test/fostgres-test.cpp
+++ b/Cpp/fostgres-test/fostgres-test.cpp
@@ -170,7 +170,8 @@ FSL_MAIN(L"fostgres-test", L"Fostgres testing environment")
         o << "Postgres error " << e.sqlstate() << std::endl;
         o << e.what() << std::endl;
     } catch (std::exception &e) {
-        o << "Caught std::exception\n\n" << e.what() << std::endl;
+        o << "Caught std::exception " << typeid(e).name() << "\n\n"
+          << e.what() << std::endl;
     } catch (...) { o << "Caught an unknown exception" << std::endl; }
     return 1;
 }

--- a/Cpp/fostgres/CMakeLists.txt
+++ b/Cpp/fostgres/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(fostgres
         datum.cpp
         file.cpp
         fostgres-control-error.cpp
+        fostgres-control-retry.cpp
         fostgres-sql.cpp
         matcher.cpp
         precondition.cpp

--- a/Cpp/fostgres/configuration.cpp
+++ b/Cpp/fostgres/configuration.cpp
@@ -1,9 +1,25 @@
-/*
-    Copyright 2015-2016, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2015-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
 #include <fost/core>
+#include <fost/test-throw-view.hpp>
+
+#include <pqxx/except>
+
+
+namespace {
+
+
+    fostlib::urlhandler::test_throw_plugin const c_serialisation{
+            "pqxx::serialization_failure", [](fostlib::string msg) {
+                throw pqxx::serialization_failure{
+                        static_cast<std::string>(msg)};
+            }};
+
+
+}

--- a/Cpp/fostgres/fostgres-control-retry.cpp
+++ b/Cpp/fostgres/fostgres-control-retry.cpp
@@ -1,0 +1,33 @@
+/**
+    Copyright 2019, Felspar Co Ltd. <http://support.felspar.com/>
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+*/
+#include <pqxx/except>
+
+#include <fostgres/response.hpp>
+
+
+namespace {
+
+
+    const class fostgres_control_error : public fostlib::urlhandler::view {
+      public:
+        fostgres_control_error() : view("fostgres.control.retry") {}
+
+        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
+                const fostlib::json &config,
+                const fostlib::string &path,
+                fostlib::http::server::request &req,
+                const fostlib::host &host) const {
+            try {
+                return execute(config["execute"], path, req, host);
+            } catch (...) {
+                throw fostlib::exceptions::not_implemented(__PRETTY_FUNCTION__);
+            }
+        }
+    } c_fostgres_control_retry;
+
+
+}

--- a/Cpp/fostgres/fostgres-control-retry.cpp
+++ b/Cpp/fostgres/fostgres-control-retry.cpp
@@ -34,12 +34,12 @@ namespace {
                     } else {
                         std::this_thread::sleep_for(25ms);
                     }
+                    ++retries;
                 }
-                ++retries;
             }
             if (retries) {
                 response.first->headers().add(
-                        "Fostgres-serialisation-retries",
+                        "Fostgres-pg-serialisation-retries",
                         fostlib::coerce<fostlib::string>(retries));
             }
             return response;

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -103,6 +103,17 @@ if(TARGET stress OR TARGET pgtest)
                 errors/test-pg-error.fg
         )
 
+    add_custom_command(OUTPUT test-pg-retry
+            COMMAND fostgres-test fostgres-test-pg-retry -o test-pg-retry
+                ${CMAKE_CURRENT_SOURCE_DIR}/../Configuration/log-show-all.json
+                $<TARGET_SONAME_FILE:fostgres>
+                ${CMAKE_CURRENT_SOURCE_DIR}/errors/test-retry.fg
+            MAIN_DEPENDENCY errors/test-retry.fg
+            DEPENDS
+                fostgres-test
+                errors/test-retry.fg
+        )
+
     ## Because of the way cmake works we need this stuff at the end to
     ## actually make the above commands run when things change.
     add_custom_target(fg-tests DEPENDS
@@ -111,6 +122,7 @@ if(TARGET stress OR TARGET pgtest)
             test-films
             test-film-t1
             test-pg-error
+            test-pg-retry
             test-users
             test-user-avatar
         )

--- a/Example/errors/test-pg-error.fg
+++ b/Example/errors/test-pg-error.fg
@@ -58,3 +58,40 @@ PUT test-pg-error /fred/friends/barney {"friend_type": "hangout"} 503
 ## ## Non-error cases work
 PUT test-pg-error /barney {"email": "barney@mail.com"} 200 {"username": "barney", "email": "barney@mail.com"}
 PUT test-pg-error /fred/friends/barney {"friend_type": "hangout"} 200
+
+
+## ## Retrying serialisation errors
+
+## If we start with a view that throws a serialisation error like this:
+
+setting webserver views/throw-serialisation {
+            "view": "test.throw",
+            "configuration": {
+                "exception": "pqxx::serialization_failure"
+            }
+        }
+
+## We can wrap it in a error handling view in order to catch the error and
+## return a 503 instead of the 500
+
+setting webserver views/serialisation-catch {
+            "view": "fostgres.control.pg-error",
+            "configuration": {
+                "execute": "throw-serialisation",
+                "40001": "fost.response.503",
+                "": "fost.response.500"
+            }
+        }
+GET serialisation-catch / 503
+
+
+## We can also retry the serialisation error.
+
+setting webserver views/test-pg-retry {
+            "view": "fostgres.control.retry",
+            "configuration": {
+                "try": "throw-serialisation",
+                "error": "fost.response.503"
+            }
+        }
+GET test-pg-retry / 503

--- a/Example/errors/test-retry.fg
+++ b/Example/errors/test-retry.fg
@@ -1,0 +1,12 @@
+## # Automatic retries
+
+setting webserver views/test-pg-retry {
+        "view": "fostgres.control.retry",
+        "configuration": {
+            "execute": {
+                "view": "fostgres.sql",
+                "configuration": {
+                }
+            }
+        }
+    }


### PR DESCRIPTION
Currently this is hard coded to 3 retries. It adds a header when retries have been used.