### PR TITLE
PATCH support

### DIFF
--- a/Cpp/fostgres/response.csj.cpp
+++ b/Cpp/fostgres/response.csj.cpp
@@ -215,14 +215,28 @@ namespace {
                 error = handler.update(linedata, records);
                 break;
             }
-            if (error.first) return error;
+            if (error.first) {
+                return error;
+            } else if (error.second) {
+                switch (error.second) {
+                case 404:
+                    return fostlib::urlhandler::view::execute(
+                            fostlib::json{"fost.response.404"}, "", req,
+                            fostlib::host{});
+                default:
+                    throw fostlib::exceptions::not_implemented(
+                            __PRETTY_FUNCTION__,
+                            "Canned response for this status code",
+                            fostlib::coerce<fostlib::string>(error.second));
+                }
+            }
             ++records;
         }
         cnx.commit();
         fostlib::insert(work_done, "records", records);
         boost::shared_ptr<fostlib::mime> response(new fostlib::text_body(
                 fostlib::json::unparse(work_done, true),
-                fostlib::mime::mime_headers(), L"application/json"));
+                fostlib::mime::mime_headers(), "application/json"));
         return std::make_pair(response, 200);
     }
 

--- a/Cpp/fostgres/response.json-csv.cpp
+++ b/Cpp/fostgres/response.json-csv.cpp
@@ -20,16 +20,15 @@ namespace {
             get(const fostlib::json &config,
                 const fostgres::match &m,
                 fostlib::http::server::request &req) {
-        auto data = m.arguments.size()
-                ? fostgres::sql(
-                          config, req,
-                          fostlib::coerce<fostlib::string>(
-                                  m.configuration["GET"]),
-                          m.arguments)
-                : fostgres::sql(
-                          config, req,
-                          fostlib::coerce<fostlib::string>(
-                                  m.configuration["GET"]));
+        auto data = m.arguments.size() ? fostgres::sql(
+                            config, req,
+                            fostlib::coerce<fostlib::string>(
+                                    m.configuration["GET"]),
+                            m.arguments)
+                                       : fostgres::sql(
+                                               config, req,
+                                               fostlib::coerce<fostlib::string>(
+                                                       m.configuration["GET"]));
         fostlib::json result;
         fostlib::insert(
                 result, "@context",

--- a/Cpp/fostgres/sql.cpp
+++ b/Cpp/fostgres/sql.cpp
@@ -266,8 +266,8 @@ std::pair<std::vector<fostlib::string>, fostlib::pg::recordset>
     } else {
         return m.arguments.size()
                 ? fostgres::sql(
-                          cnx, fostlib::coerce<fostlib::string>(select),
-                          m.arguments)
+                        cnx, fostlib::coerce<fostlib::string>(select),
+                        m.arguments)
                 : fostgres::sql(cnx, fostlib::coerce<fostlib::string>(select));
     }
 }

--- a/Cpp/fostgres/updater.cpp
+++ b/Cpp/fostgres/updater.cpp
@@ -106,7 +106,16 @@ std::pair<boost::shared_ptr<fostlib::mime>, int> fostgres::updater::insert(
 std::pair<boost::shared_ptr<fostlib::mime>, int> fostgres::updater::update(
         fostgres::updater::intermediate_data d,
         std::optional<std::size_t> row) {
-    cnx.update(relation.c_str(), d.first, d.second);
+    std::vector<fostlib::string> returning = {"*"};
+    auto rs = cnx.update(relation.c_str(), d.first, d.second, returning);
+    auto pos = rs.begin();
+    if (pos == rs.end()) {
+        return {nullptr, 404};
+    } else if (++pos != rs.end()) {
+        throw fostlib::exceptions::not_implemented(
+                __PRETTY_FUNCTION__,
+                "Update for multiple rows not supported by Fostgres");
+    }
     return {nullptr, 0};
 }
 

--- a/Example/films/films.fg
+++ b/Example/films/films.fg
@@ -6,7 +6,7 @@
 ## `UPDATE` statements instead of `INSERT` ones. If these don't actually
 ## update anything then we will get a 404 back, denoting that the
 ## resource we're trying to update doesn't exist.
-#PATCH film.slug.error / (module.path.join films.edit.csj) 404
+PATCH film.slug.error / (module.path.join films.edit.csj) 404
 
 
 ## ## Add films normally


### PR DESCRIPTION
This completes the PATCH support by implementing the remaining parts so it works consistently for both object and CSJ requests.