### PR TITLE
Fix for changes in libpqxx

### DIFF
--- a/Cpp/fostgres/fostgres-control-error.cpp
+++ b/Cpp/fostgres/fostgres-control-error.cpp
@@ -40,7 +40,7 @@ namespace {
                 } else {
                     return execute(config[""], path, req, host);
                 }
-            } catch (pqxx::pqxx_exception const &e) {
+            } catch (pqxx::failure const &e) {
                 return execute(config[""], path, req, host);
             }
         }


### PR DESCRIPTION
This fixes a problem with libpqxx HEAD. It is needed to get current develop to pass Travis tests and to get https://github.com/KayEss/odin/pull/85 to pass on Travis.